### PR TITLE
Remove validators from propertySheetSchema

### DIFF
--- a/legacy-iframe-launcher/test/legacy_iframe_launcher_spec.js
+++ b/legacy-iframe-launcher/test/legacy_iframe_launcher_spec.js
@@ -164,11 +164,20 @@ describe('legacy iframe launcher', function(){
   describe('some other APIs', function(){
     it('setPropertySheetAttributes', function(done){
       launcher.addEventListener('setPropertySheetAttributes', function(evt){
-        expect(evt.detail).to.eql({ foo: 'bar' });
+        expect(evt.detail).to.eql({ foo: { type: 'string' } });
         done();
       });
 
-      legacyLauncher._propertySheetSchema.set({ foo: 'bar' });
+      legacyLauncher._propertySheetSchema.set({ foo: { type: 'string' } });
+    });
+
+    it('setPropertySheetAttributes with validators omits validators', function(done){
+      launcher.addEventListener('setPropertySheetAttributes', function(evt){
+        expect(evt.detail.foo).not.to.include.keys('validators');
+        done();
+      });
+
+      legacyLauncher._propertySheetSchema.set({ foo: { type: 'string', validators: [function(){}] }});
     });
 
     it('setEmpty', function(done){

--- a/legacy-iframe-launcher/versal.html
+++ b/legacy-iframe-launcher/versal.html
@@ -41,7 +41,7 @@ player.on('environmentChanged', function(env){
   });
 
   launcher.addEventListener('setPropertySheetAttributes', function(evt){
-    player.setPropertySheetAttributes(evt.detail);
+    player.setPropertySheetAttributes(_cleanupPropertySheetValidators(evt.detail));
   });
 
   launcher.addEventListener('setEmpty', function(evt){
@@ -70,6 +70,16 @@ player.on('editableChanged', function(evt){
 });
 
 player.startListening();
+
+function _cleanupPropertySheetValidators(schema) {
+  if(!_.isObject(schema)) return schema;
+
+  var cleanedUpSchema = _.chain(schema).pairs().map(function(pair){
+    return [pair[0], _.omit(pair[1], 'validators')];
+  }).object().value();
+
+  return cleanedUpSchema;
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
Because JSON objects, passed via postMessage, cannot contain functions.