### PR TITLE
fix typo in the name of the launcher html element

### DIFF
--- a/legacy-launcher/legacy-launcher.html
+++ b/legacy-launcher/legacy-launcher.html
@@ -1,7 +1,7 @@
 <!-- Temporarily disable legacy CSS because it breaks gadgets
 <link rel="stylesheet" href="legacy-launcher.css"> -->
 <style>
-versal-gadget-launcher {
+versal-legacy-launcher {
   display: block;
   font-family: Georgia, serif;
   font-size: 16px;


### PR DESCRIPTION
"versal-gadget-launcher" is invalid, must be "versal-legacy-launcher"