### PR TITLE
Fix problem with detaching iframe launcher in Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "underscore": "~1.6.0",
     "backbone": "1.0.0",
     "jquery": "~2.1.1",
-    "webcomponentsjs": "~0.5.1"
+    "webcomponentsjs": "~0.5.4"
   },
   "dependencies": {
     "requirejs": "2.1.6",

--- a/iframe-launcher/iframe-launcher.js
+++ b/iframe-launcher/iframe-launcher.js
@@ -93,6 +93,10 @@ prototype.attachedCallback = function(){
 
 prototype.detachedCallback = function(){
   this.removeChild(this.iframe);
+  this._reset();
+};
+
+prototype._reset = function(){
   this._previousMessages = {};
   window.clearTimeout(this._attributesChangedTimeout);
   window.clearTimeout(this._learnerStateChangedTimeout);
@@ -161,6 +165,7 @@ prototype.fireCustomEvent = function(eventName, data, options) {
 
 prototype.messageHandlers = {
   startListening: function(){
+    this._reset();
     this._listening = true;
     this.sendMessage('environmentChanged', this.env);
     this.sendMessage('attributesChanged', this.config);

--- a/iframe-launcher/test/launcher_spec.js
+++ b/iframe-launcher/test/launcher_spec.js
@@ -51,6 +51,25 @@ describe('iframe launcher', function() {
       };
     });
 
+    it('sends a bunch of initial events every time it receives startListening', function(done) {
+      var recordedEvents = [];
+
+      // Simulate detaching and attaching iframe, for example, when moving slides in slideshow
+      setTimeout(function(){
+        launcher.children[0].contentWindow.sendGadgetEvent({event: 'startListening'});
+      }, 100);
+
+      window.recordPlayerEvent = function(eventMessage) {
+        recordedEvents.push(eventMessage);
+
+        if(recordedEvents.length == 8) {
+          delete window.recordPlayerEvent;
+          done();
+        }
+      };
+    });
+
+
     it('sends attributesChanged when data-config changes', function(done) {
       window.recordPlayerEvent = function(eventMessage) {
         if (eventMessage.event == 'editableChanged') {


### PR DESCRIPTION
Problem occurs when iframe-launcher is moved around in the DOM. That trigger iframe reloading, but detached callback doesn't fire in Firefox because polyfill is deficient (https://github.com/webcomponents/webcomponentsjs/issues/18).

Luckily, `startListening` event still arrives, so we can use it to reset state of the component and send initial events every time `startListening` arrives.

Fixes GAD-208