### PR TITLE
avoid creating and initializing the content iframe if one already exists

### DIFF
--- a/iframe-launcher/iframe-launcher.js
+++ b/iframe-launcher/iframe-launcher.js
@@ -178,7 +178,10 @@ prototype.createdCallback = function() {
 
 prototype.attachedCallback = function(){
   // avoid problems in case attachedCallback is called multiple times while detachedCallback is not called
-  if (this.iframe) return;
+  if (this.iframe) {
+    if (this.iframe.src != this.src) this.iframe.src = this.src;
+    return;
+  }
 
   this.iframe = document.createElement('iframe');
   this.iframe.src = this.src;

--- a/iframe-launcher/iframe-launcher.js
+++ b/iframe-launcher/iframe-launcher.js
@@ -177,6 +177,9 @@ prototype.createdCallback = function() {
 };
 
 prototype.attachedCallback = function(){
+  // avoid problems in case attachedCallback is called multiple times while detachedCallback is not called
+  if (this.iframe) return;
+
   this.iframe = document.createElement('iframe');
   this.iframe.src = this.src;
   this.iframe.addEventListener('message', this.handleMessage.bind(this));
@@ -195,6 +198,7 @@ prototype.attachedCallback = function(){
 
 prototype.detachedCallback = function(){
   this.removeChild(this.iframe);
+  this.iframe = null;
   this.removeChild(this.assetInput);
   this.removeChild(this.assetDropzone);
   this.removeChild(this.loadingOverlay);


### PR DESCRIPTION
In Safari, `attachedCallback` may be called twice. We now avoid creating two iframes in this case.