### PR TITLE
bump version of versal-gadget-api 0.0.10 -> 0.0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "requirejs": "2.1.6",
     "customevent-polyfill": "~1.0.0",
-    "versal-gadget-api": "~0.0.10",
+    "versal-gadget-api": "~0.0.14",
     "fontawesome": "~3.2.1"
   }
 }


### PR DESCRIPTION
In an attempt to resolve https://versal.atlassian.net/browse/POR-5914 we make sure that versal-gadget-api 0.0.14 is used everywhere